### PR TITLE
Utilize In Mem Cache for last 1k positions

### DIFF
--- a/src/cache.go
+++ b/src/cache.go
@@ -1,0 +1,69 @@
+package src
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type cache struct {
+	log    *zap.Logger
+	db     *dbManager
+	mutex  *sync.Mutex
+	ticker *time.Ticker
+	data   []position
+}
+
+func NewCache(log *zap.Logger, db *dbManager) *cache {
+	c := &cache{
+		log:    log,
+		db:     db,
+		mutex:  &sync.Mutex{},
+		ticker: time.NewTicker(2 * time.Minute),
+	}
+	c.refresh() // initial refresh
+
+	return c
+}
+
+// Run the cache obtains the last 1000 positios from the database using a ticker
+// at in interval of once very 5 minutes and updates the cache with the new data
+func (c *cache) Run() {
+	for range c.ticker.C {
+		c.refresh()
+	}
+}
+
+func (c *cache) refresh() {
+	startTs := time.Now()
+	latestPosition, err := c.db.getLatestPosition()
+	if err != nil {
+		c.log.Error("error getting latest position", zap.Error(err))
+		return
+	}
+
+	positions, err := c.db.fetchPositions(latestPosition.ID - 1000)
+	if err != nil {
+		c.log.Error("error getting last 1000 positions", zap.Error(err))
+		return
+	}
+
+	c.mutex.Lock()
+	c.data = positions
+	c.mutex.Unlock()
+
+	c.log.Info("cache updated with last 1000 positions", zap.Duration("duration", time.Since(startTs)))
+}
+
+func (c *cache) Close() {
+	c.ticker.Stop()
+}
+
+// getPositions returns the last 1000 positions from the cache
+func (c *cache) getPositions() []position {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.data
+}

--- a/src/db.go
+++ b/src/db.go
@@ -103,7 +103,7 @@ func (db *dbManager) fetchPositions(id int) ([]position, error) {
 			positions
 		WHERE id > ?
 		ORDER BY id ASC
-		LIMIT 3000;
+		LIMIT 2000;
 	`
 
 	rows, err := db.db.Query(q, id)

--- a/src/worm.go
+++ b/src/worm.go
@@ -51,7 +51,7 @@ func Run(log *zap.Logger, fetcher *blockFetcher, db *dbManager) error {
 				if err != nil {
 					log.Error("fetcher error", zap.Error(err))
 				} else {
-					log.Info("fetcher returned, sleeping for 1 minute")
+					log.Info("fetcher returned, sleeping for 20 seconds")
 				}
 				time.Sleep(20 * time.Second)
 			}


### PR DESCRIPTION
This PR introduces a simple in memory cache that will hold the last 1000 positions. When a request comes in that specifies -1 in order to signal all positions the request handler will instead utilize the cache for the last 1k and then append any yet uncached new positions. 
